### PR TITLE
Fix copy-paste bug in make.S.R parameter validation

### DIFF
--- a/R/make.S.R
+++ b/R/make.S.R
@@ -9,10 +9,10 @@ function(scrFrame,buffer,res,xy=NULL){
  if(is.null(xy)) xy <- c(1,2)
                    #res is the resolution for your state space
                  
-  if(res==NULL) stop("You didnt provide a resolution value!")
-                   #buffer is the required buffer 
-                   
-if(res==NULL)stop("You didnt provide a buffer value!")
+  if(is.null(res)) stop("You didnt provide a resolution value!")
+                   #buffer is the required buffer
+
+if(is.null(buffer))stop("You didnt provide a buffer value!")
                  
    S <- list()
                  


### PR DESCRIPTION
Fixed a bug where the buffer parameter validation was incorrectly checking the res variable instead of buffer. Also improved null checks to use is.null() instead of ==NULL for R best practices.

Bug details:
- Line 15 was checking if(res==NULL) but error message said "buffer value"
- This meant buffer parameter was never validated
- Changed to correctly check if(is.null(buffer))